### PR TITLE
docs: 说明分片为字节级切割，新增 mergePDFs.bat / mergePDFs.sh 一键合并脚本

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,28 +49,42 @@
 
 由于 GitHub 对单个文件的上传有最大限制，超过 100MB 的文件会被拒绝上传，超过 50MB 的文件上传时会收到警告。因此，文件大小超过 50MB 的文件会被拆分成每个 35MB 的多个文件。
 
-### 示例
-文件被拆分的示例：
-- 义务教育教科书 · 数学一年级上册.pdf.1
-- 义务教育教科书 · 数学一年级上册.pdf.2
+分片是按字节顺序直接切割的（类似分卷压缩），不涉及 PDF 内部结构，按序号拼接即可还原为与原文件完全一致的单个 PDF。分片有时位于专门的 `xxx.pdf_merge_folder/` 子目录中，有时直接与其他文件同目录；另有少数书籍同时存在「整本 PDF」与「分片」两种形式（内容一致），任取其一即可，无需合并。
 
-### 解决办法
-要合并这些被拆分的文件，您只需执行以下步骤(其他操作系统同理)：
-1. 将合并程序 `mergePDFs-windows-amd64.exe` 下载到包含 PDF 文件的文件夹中。
-2. 确保 `mergePDFs-windows-amd64.exe` 和被拆分的 PDF 文件在同一目录下。
-3. 双击 `mergePDFs-windows-amd64.exe` 程序即可自动完成文件合并。
+### 一键脚本
 
-### 下载方式
-您可以通过以下链接，下载文件合并程序：
+本仓库根目录提供两个脚本，放到需要处理的目录（或其上级目录）中运行即可递归合并所有分片，已存在整本的书籍会自动跳过：
 
-[下载文件合并程序](https://github.com/TapXWorld/ChinaTextbook-tools/releases)
+- Windows：双击 `mergePDFs.bat`
+- macOS / Linux：`sh mergePDFs.sh`
 
+### 手动合并（Windows）
+
+使用系统自带的 `copy /b`（分片多于两个时按 `.1` `.2` `.3` … 顺序依次相加）：
+
+```bat
+copy /b "义务教育教科书·数学一年级上册.pdf.1"+"义务教育教科书·数学一年级上册.pdf.2" "义务教育教科书·数学一年级上册.pdf"
+```
+
+### 手动合并（macOS / Linux）
+
+使用系统自带的 `cat`（分片多于两个时按顺序全部列出）：
+
+```bash
+cat "义务教育教科书·数学一年级上册.pdf.1" "义务教育教科书·数学一年级上册.pdf.2" > "义务教育教科书·数学一年级上册.pdf"
+```
+
+### 图形化合并程序（Windows）
+
+将 `mergePDFs-windows-amd64.exe` 下载到包含 PDF 文件的文件夹中，双击即可自动完成文件合并。
+
+下载地址：[下载文件合并程序](https://github.com/TapXWorld/ChinaTextbook-tools/releases)
 
 ### 文件和程序示例
-- mergePDFs-windows-amd64.exe
-- 义务教育教科书 · 数学一年级上册.pdf.1
-- 义务教育教科书 · 数学一年级上册.pdf.2
 
+- mergePDFs-windows-amd64.exe
+- 义务教育教科书·数学一年级上册.pdf.1
+- 义务教育教科书·数学一年级上册.pdf.2
 
 ## 重新下载
 - 如果您位于内地，并且网络不错，想重新下载，您可以使用 [tchMaterial-parser](https://github.com/happycola233/tchMaterial-parser) 项目（鼓励开源），进行重新下载。

--- a/mergePDFs.bat
+++ b/mergePDFs.bat
@@ -1,0 +1,64 @@
+@echo off
+setlocal EnableExtensions
+chcp 65001 >nul
+rem ============================================================
+rem 合并 ChinaTextbook 仓库中被拆分的 PDF 分片(书名.pdf.1, 书名.pdf.2 ...)
+rem 用法: 将本文件放到需要处理的目录(或其上级目录), 双击运行。
+rem 会递归处理当前目录下所有分片, 在分片所在目录生成 "书名.pdf";
+rem 若 "书名.pdf" 已存在(例如该书同时有整本形式)则跳过。
+rem 本脚本不会删除任何文件。分片为字节级切割, 按序号拼接即可还原。
+rem 注意: 若文件名中含有 + 或 %% 字符, 请改用 copy /b 手动合并。
+rem ============================================================
+
+set /a MERGED=0
+set /a SKIPPED=0
+set /a FAILED=0
+
+for /r %%F in (*.pdf.1) do call :merge_one "%%~dpF" "%%~nF"
+
+echo.
+echo 完成: 合并 %MERGED% 个, 跳过 %SKIPPED% 个, 失败 %FAILED% 个。
+echo 确认无误后可自行删除各 *.pdf.N 分片。
+pause
+exit /b 0
+
+:merge_one
+rem 参数: %1 = 目录(以\结尾)   %2 = 书名.pdf (不含 .N 序号)
+set "OUTBASE=%~1%~2"
+if exist "%OUTBASE%" (
+    set /a SKIPPED+=1
+    echo [跳过] 已存在整本: %~2
+    goto :eof
+)
+set "LIST="
+set /a TOTAL=0
+set /a K=1
+:collect
+if not exist "%OUTBASE%.%K%" goto :domerge
+call :size "%OUTBASE%.%K%" SZ
+set /a TOTAL+=SZ
+if defined LIST (set "LIST=%LIST%+"%OUTBASE%.%K%"") else (set "LIST="%OUTBASE%.%K%"")
+set /a K+=1
+goto :collect
+:domerge
+if not defined LIST (
+    set /a FAILED+=1
+    echo [失败] 未找到分片: %~2
+    goto :eof
+)
+copy /b %LIST% "%OUTBASE%" >nul
+call :size "%OUTBASE%" GOT
+if %GOT% NEQ %TOTAL% (
+    set /a FAILED+=1
+    echo [失败] 大小不符, 已删除输出, 请检查分片是否齐全: %~2
+    del "%OUTBASE%" 2>nul
+    goto :eof
+)
+set /a MERGED+=1
+echo [合并] %~2 ^(%K% 片, %GOT% 字节^)
+goto :eof
+
+:size
+rem 参数: %1 = 文件   %2 = 接收大小的变量名
+for %%Z in ("%~1") do set "%~2=%%~zZ"
+goto :eof

--- a/mergePDFs.sh
+++ b/mergePDFs.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# 合并 ChinaTextbook 仓库中被拆分的 PDF 分片（书名.pdf.1、书名.pdf.2 …）。
+# 用法: 将本脚本放到需要处理的目录（或其上级目录）中, 在该目录下执行:
+#   sh mergePDFs.sh
+# 会递归处理当前目录下所有分片, 在分片所在目录生成 "书名.pdf";
+# 分片为字节级切割, 按序号直接拼接即可还原。脚本不会删除任何文件。
+# 若 "书名.pdf" 已存在（例如该书同时有整本形式）则跳过。
+
+set -eu
+
+merged=0
+skipped=0
+failed=0
+
+find . -type f -name '*.pdf.1' | (while IFS= read -r first; do
+    base="${first%.pdf.1}"
+    out="$base.pdf"
+
+    if [ -f "$out" ]; then
+        echo "[跳过] 已存在整本: $out"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # 按序号 1,2,3… 依次收集分片（避免 .10 排到 .2 前的字典序问题）
+    list=''
+    expect=0
+    k=1
+    while [ -f "$base.pdf.$k" ]; do
+        if [ -n "$list" ]; then
+            list="$list \"$base.pdf.$k\""
+        else
+            list="\"$base.pdf.$k\""
+        fi
+        expect=$((expect + $(wc -c < "$base.pdf.$k" | tr -d ' ')))
+        k=$((k + 1))
+    done
+
+    # shellcheck disable=SC2086
+    if eval "cat $list" > "$out"; then
+        got=$(wc -c < "$out" | tr -d ' ')
+        head4=$(head -c 4 "$out" 2>/dev/null || true)
+        if [ "$got" != "$expect" ] || [ "$head4" != "%PDF" ] \
+           || ! tail -c 2048 "$out" | grep -aq '%%EOF'; then
+            echo "[失败] 校验不通过, 已删除: $out (期望 $expect 字节, 实际 $got)"
+            rm -f "$out"
+            failed=$((failed + 1))
+        else
+            echo "[合并] $out ($got 字节, $((k - 1)) 片)"
+            merged=$((merged + 1))
+        fi
+    else
+        echo "[失败] 拼接出错: $out"
+        rm -f "$out"
+        failed=$((failed + 1))
+    fi
+done
+echo
+echo "完成: 合并 $merged 个, 跳过 $skipped 个, 失败 $failed 个。"
+echo "确认无误后可自行删除各 *.pdf.N 分片。")


### PR DESCRIPTION
## 背景

对仓库快照（commit `5a80345`）的全量审计发现：

- 被拆分的 PDF 共 **182 本**（466 个分片），其中 122 本的分片**直接存放在普通目录中**，其余 60 本位于 `xxx.pdf_merge_folder/` 子目录——两种存放位置并存；
- 少数书籍（26 本）同时存在「整本 PDF」与「分片」两种形式，经 CRC32 比对，**分片按序拼接与整本字节完全一致**；
- 即分片为**按字节顺序切割**（类似分卷压缩），不涉及 PDF 内部结构，用系统自带命令拼接即可完整还原，无需专用工具，Windows 的 `copy /b` 与 macOS/Linux 的 `cat` 均可。

## 改动

1. **README.md**（「问题：如何合并被拆分的文件？」一节）：
   - 说明分片为字节级切割、可直接拼接还原；
   - 说明分片的两种存放位置，以及「整本/分片并存」时任取其一即可；
   - 新增 Windows `copy /b` 与 macOS/Linux `cat` 的手动合并示例；
   - 保留原有图形化合并程序的说明。
2. **新增 `mergePDFs.bat`（Windows）/ `mergePDFs.sh`（macOS/Linux）**：
   - 递归合并当前目录下所有 `书名.pdf.N` 分片，在分片所在目录生成 `书名.pdf`；
   - 按**数字序**递增收集分片（避免 `.pdf.10` 排在 `.pdf.2` 之前的字典序问题）；
   - 合并后校验（大小一致，sh 版另校验 `%PDF-` 文件头与 `%%EOF` 文件尾），校验不通过则删除输出并报告，不产出损坏文件；
   - 已存在整本的书籍自动跳过；**不删除任何文件**。

## 测试

- `mergePDFs.sh` 已在 macOS（`/bin/sh`）实测通过：11 片（跨 10 排序）、中文/空格/括号文件名、嵌套子目录、整本并存跳过、缺失分片失败回退、二次运行幂等；合并结果与原文件 `cmp` 逐字节一致；
- `mergePDFs.bat` 采用保守写法（`call` 子例程 + 单次 `copy /b` + 大小回验 + `chcp 65001`），未在 Windows 真机实测，欢迎试用反馈。
